### PR TITLE
Sleekweasel patch 1

### DIFF
--- a/PatienceDiff.html
+++ b/PatienceDiff.html
@@ -73,6 +73,7 @@ function autocalc() {
 version: 3.0 
   --- <a href='https://github.com/sleekweasel/PatienceDiff'>https://github.com/sleekweasel/PatienceDiff</a>
   --- <a href='https://github.com/sleekweasel/PatienceDiff/deployments'>https://github.com/sleekweasel/PatienceDiff/deployments</a>
+  --- branch sleekweasel-patch-1 with join that seems to fix findUnique
 <br>
   <input type="radio" name="auto" id="checkdiff" onclick="calcDiff(true)"><button type="button" onclick="calcDiff(true)">=&gt; Diff =&gt;</button>
   <input type="radio" name="auto" id="checkplus" onclick="calcDiff(false)" checked><button type="button" onclick="calcDiff(false)">=&gt; DiffPlus =&gt;</button>

--- a/PatienceDiff.js
+++ b/PatienceDiff.js
@@ -54,7 +54,7 @@ function patienceDiff( aLines, bLines, diffPlusFlag ) {
 
 		for ( let i = lo; i <= hi + 1 - unit; i ++ ) {
 
-			let line = arr.slice( i, i + unit );
+			let line = arr.slice( i, i + unit ).join("\n");
       
 			if ( lineMap.has( line ) ) {
 


### PR DESCRIPTION
Work-around for using sets as the key of the map while collecting unique lines: doesn't seem to work on Chrome/MacOS